### PR TITLE
Fix/transaction discount fee

### DIFF
--- a/woo-yapay/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -404,7 +404,6 @@ class WC_Yapay_Intermediador_Creditcard_Gateway extends WC_Payment_Gateway {
         
         $params["payment[split]"] = $_POST["wc-yapay_intermediador-cc_card_installments"];
         
-        error_log( var_export( $params, true ) ); exit;
         $tcRequest = new WC_Yapay_Intermediador_Request();
 
         $tcResponse = $tcRequest->requestData("v2/transactions/pay_complete",$params,$this->get_option("environment"),false);

--- a/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
@@ -272,31 +272,33 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
             $params["transaction[shipping_price]"] = $order->order_shipping;
         }
         
+        $discount = 0;
+        $fee      = 0;
+
         if (count($order->get_items('fee')) > 0) {
-            add_filter ( 'additional_fees', 'yp_additional_fees', 10, 2  );
     
-            function yp_additional_fees( $discount, $order ) {
-                foreach( $order->get_items('fee') as $item_id => $item_fee ){
-                    $fee_total = $item_fee->get_total();
+            foreach( $order->get_items('fee') as $item_id => $item_fee ){
+                $fee_total = intval( $item_fee->get_total() );
+
+                if ( $fee_total > 0 ) {
+                    $fee += $fee_total;
+                } else {
+                    $discount += $fee_total * -1;
                 }
-            
-                if( $discount > 0 ) {
-                    $total_fee = $discount + abs($fee_total);
-                    return $total_fee;
-                }
-                return abs($fee_total);
             }
-
-
-            $params["transaction[price_discount]"] = apply_filters( 'additional_fees', $order->discount_total, $order );
-
-
-        } else if (intval($order->discount_total) > 0) {
-            $params["transaction[price_discount]"] = $order->discount_total;
-            
         } 
 
-        // $params["transaction[price_discount]"] = $order->discount_total;
+        $discount += $order->discount_total;
+
+        if ( $discount > 0 ) {
+            $params["transaction[price_discount]"] = $discount;
+        }
+
+        if ( $fee > 0 ) {
+            $params["transaction[fee]"] = $fee;
+        }
+        
+
         $params["transaction[url_notification]"] = $this->get_wc_request_url($order_id);
         $params["transaction[available_payment_methods]"] = implode(",",$this->get_option("payment_methods"));
         

--- a/woo-yapay/class-wc-yapay_intermediador-tef-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-tef-gateway.php
@@ -276,31 +276,32 @@ class WC_Yapay_Intermediador_Tef_Gateway extends WC_Payment_Gateway {
             $params["transaction[shipping_price]"] = $order->order_shipping;
         }
         
+        $discount = 0;
+        $fee      = 0;
+
         if (count($order->get_items('fee')) > 0) {
-            add_filter ( 'additional_fees', 'yp_additional_fees', 10, 2  );
     
-            function yp_additional_fees( $discount, $order ) {
-                foreach( $order->get_items('fee') as $item_id => $item_fee ){
-                    $fee_total = $item_fee->get_total();
+            foreach( $order->get_items('fee') as $item_id => $item_fee ){
+                $fee_total = intval( $item_fee->get_total() );
+
+                if ( $fee_total > 0 ) {
+                    $fee += $fee_total;
+                } else {
+                    $discount += $fee_total * -1;
                 }
-            
-                if( $discount > 0 ) {
-                    $total_fee = $discount + abs($fee_total);
-                    return $total_fee;
-                }
-                return abs($fee_total);
             }
-
-
-            $params["transaction[price_discount]"] = apply_filters( 'additional_fees', $order->discount_total, $order );
-
-
-        } else if (intval($order->discount_total) > 0) {
-            $params["transaction[price_discount]"] = $order->discount_total;
-            
         } 
 
-        // $params["transaction[price_discount]"] = $order->discount_total;
+        $discount += $order->discount_total;
+
+        if ( $discount > 0 ) {
+            $params["transaction[price_discount]"] = $discount;
+        }
+
+        if ( $fee > 0 ) {
+            $params["transaction[fee]"] = $fee;
+        }
+        
         $params["transaction[url_notification]"] = $this->get_wc_request_url($order_id);
         $params["transaction[available_payment_methods]"] = implode(",",$this->get_option("payment_methods"));
         


### PR DESCRIPTION
# GitHub Issue #21 

## O que mudou
Nova maneira de distribuir taxas e descontos durante o processamento de pedidos.

## Motivação
A utilização de fees(taxas) do WooCommerce acabava entrando como desconto, gerando um valor diferente do esperado.

## Solução proposta
Refatorei a forma como as taxas eram distribuídas. Se a taxa for negativa ela entra como desconto, se positiva como taxa. Além disso os valores de desconto por coupons são somados aos descontos de taxas(negativas)

## Como testar
Realizar compra com uma taxa definida.
