### PR TITLE
Fix/cpf_pix_transaction

### DIFF
--- a/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
@@ -184,27 +184,27 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 
-        if ($_POST["billing_persontype"] == 2) {
+        if ( isset( $_POST["billing_persontype"] ) && $_POST["billing_persontype"] == 2 ) {
             $params["customer[trade_name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
             $params["customer[company_name]"] = $_POST["billing_company"];
             $params["customer[cnpj]"] = $_POST["billing_cnpj"];
 
-            if ($_POST["yapay_cpfT"] == "") {
-                $params["customer[cpf]"] = $_POST["billing_cpf"];
+            if ( ! isset( $_POST["yapay_cpf_pix"] ) || $_POST["yapay_cpf_pix"] == "" ) {
+                wc_add_notice(  "O campo CPF é obrigatório!", "error" );
+                return;
             }
-            else {
-                $params["customer[cpf]"] = $_POST["yapay_cpfT"];
-            }
+
+            $params["customer[cpf]"] = $_POST["yapay_cpf_pix"];
+            
         } else {
             if (($_POST["billing_persontype"] == NULL) AND ($_POST["billing_cpf"] == NULL) ) {
-                $params["customer[cpf]"] = $_POST["yapay_cpfT"];
+                $params["customer[cpf]"] = $_POST["yapay_cpf_pix"];
                 $params["customer[trade_name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
                 $params["customer[company_name]"] = $_POST["billing_company"];
                 $params["customer[cnpj]"] = $_POST["billing_cnpj"];
             } 
         }
-
-
+        
 
         $params["customer[inscricao_municipal]"] = "";
         $params["customer[email]"] = $_POST["billing_email"];

--- a/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
@@ -189,16 +189,16 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
             $params["customer[company_name]"] = $_POST["billing_company"];
             $params["customer[cnpj]"] = $_POST["billing_cnpj"];
 
-            if ( ! isset( $_POST["yapay_cpf_pix"] ) || $_POST["yapay_cpf_pix"] == "" ) {
+            if ( ! isset( $_POST["yapay_cpfP"] ) || $_POST["yapay_cpfP"] == "" ) {
                 wc_add_notice(  "O campo CPF é obrigatório!", "error" );
                 return;
             }
 
-            $params["customer[cpf]"] = $_POST["yapay_cpf_pix"];
+            $params["customer[cpf]"] = $_POST["yapay_cpfP"];
             
         } else {
             if (($_POST["billing_persontype"] == NULL) AND ($_POST["billing_cpf"] == NULL) ) {
-                $params["customer[cpf]"] = $_POST["yapay_cpf_pix"];
+                $params["customer[cpf]"] = $_POST["yapay_cpfP"];
                 $params["customer[trade_name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
                 $params["customer[company_name]"] = $_POST["billing_company"];
                 $params["customer[cnpj]"] = $_POST["billing_cnpj"];

--- a/woo-yapay/templates/wc_yapay_intermediador_pix_form.php
+++ b/woo-yapay/templates/wc_yapay_intermediador_pix_form.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
     <div id="cpf_yapayB" class="cpf_yapay" style="display: none">  	
 	    <label>CPF<strong style="color: red;">*</strong> (somente números)</label>
-        <input type="text" class="input-text yapay_cpf" onkeyup="somenteNumeros(this)" id="yapay_cpfB" type="text" name="yapay_cpfB" maxlength="11" required>
+        <input type="text" class="input-text yapay_cpf" onkeyup="somenteNumeros(this)" id="yapay_cpf_pix" type="text" name="yapay_cpf_pix" maxlength="11" required>
     </div>
 
 

--- a/woo-yapay/templates/wc_yapay_intermediador_pix_form.php
+++ b/woo-yapay/templates/wc_yapay_intermediador_pix_form.php
@@ -17,9 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     </ul>
 
 
-    <div id="cpf_yapayB" class="cpf_yapay" style="display: none">  	
+    <div id="cpf_yapayP" class="cpf_yapay" style="display: none">  	
 	    <label>CPF<strong style="color: red;">*</strong> (somente números)</label>
-        <input type="text" class="input-text yapay_cpf" onkeyup="somenteNumeros(this)" id="yapay_cpf_pix" type="text" name="yapay_cpf_pix" maxlength="11" required>
+        <input type="text" class="input-text yapay_cpf" onkeyup="somenteNumeros(this)" id="yapay_cpfP" type="text" name="yapay_cpfP" maxlength="11" required>
     </div>
 
 


### PR DESCRIPTION
# GitHub Issue #22 

## **O que mudou**
Verificação do preenchimento do campo de CPF para compras feitas como pessoas jurídicas.

## **Motivação**
Mesmo preenchendo corretamente o campo de CPF, a informação não era enviada corretamente.

## **Solução proposta**
Refatorei a verificação que era feita, e alterei o nome do parâmetro usado para buscar o valor do CPF.

## **Como testar**
Realizar uma compra usando dados de pessoa jurídica.