### PR TITLE
Feat/yapay_order_view

### DIFF
--- a/woo-yapay/assets/css/styles.css
+++ b/woo-yapay/assets/css/styles.css
@@ -151,3 +151,32 @@ ul li img.tcPaymentFlagSelected{
     width: 100px;
 
 }
+
+/** Order view page */
+#yapay-order-container h2 {
+    font-weight: 600;
+}
+
+#yapay-order-container .section-row {
+    margin: 5px 0;
+}
+
+#yapay-order-container #yapay-billet-link {
+    margin-top: 5px;
+    margin-bottom: 10px;
+}
+
+#yapay-order-container #yapay-billet-link > a {
+    text-decoration: none;
+    text-transform: uppercase;
+    padding: 8px 15px;
+    font-size: 14px;
+    font-weight: 600;
+    background: #eeee;
+    color: #333333;
+    margin: 5px 0;
+}
+
+#yapay-order-container #yapay-pix-qr > object{
+    margin-left: -75px;
+}

--- a/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
@@ -462,7 +462,7 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
             $order_id = $order->get_id();
 
             $dados = $this->get_meta_data( $order_id );
-            error_log( var_export( $dados, true ) );
+            
             extract($dados);
             ob_start();
 

--- a/woo-yapay/templates/orders/wc_yapay_intermediador_bs_order.php
+++ b/woo-yapay/templates/orders/wc_yapay_intermediador_bs_order.php
@@ -1,0 +1,25 @@
+<div class="order-view-section">
+    <div id="yapay-order-container">
+        <h2 class="section-title"><?php echo __( "Yapay Intermediador","wc-yapay_intermediador-bs" ); ?></h2>
+        <p>
+            <div class="section-row">
+                <strong><?php echo __( "Método de pagamento: ", "wc-yapay_intermediador-bs" ) ;?></strong>
+                <span><?php echo esc_html( "Boleto Bancário - Yapay Intermediador" ); ?></span>
+            </div>
+            <div class="section-row">
+                <strong><?php echo __( "Yapay transaction ID:  ", "wc-yapay_intermediador-bs" ); ?></strong>
+                <span><?php echo esc_html( $yapay_transaction_id ); ?></span>
+            </div>
+            <div class="section-row">
+                <strong><?php echo __( "Download do boleto:   ", "wc-yapay_intermediador-bs" ); ?></strong><br>
+                <div id="yapay-billet-link">
+                    <a target="_blank" href="<?php echo esc_url( $yapay_bankslip_url )?>"><?php echo esc_html( "Imprimir Boleto" ); ?></a>
+                </div>
+            </div>
+            <div class="section-row">
+                <strong><?php echo __( "Linha digitável:  ", "wc-yapay_intermediador-bs" ); ?></strong>
+                <span><?php echo esc_html( $yapay_bankslip_code ); ?>"</span>
+            </div>
+        </p>
+    </div>
+</div>

--- a/woo-yapay/templates/orders/wc_yapay_intermediador_pix_order.php
+++ b/woo-yapay/templates/orders/wc_yapay_intermediador_pix_order.php
@@ -1,0 +1,27 @@
+<div class="order-view-section">
+    <div id="yapay-order-container">
+        <h2 class="section-title"><?php echo __( "Yapay Intermediador","wc-yapay_intermediador-pix" ); ?></h2>
+        <p>
+            <div class="section-row">
+                <strong><?php echo __( "Método de pagamento: ", "wc-yapay_intermediador-pix" ) ;?></strong>
+                <span><?php echo esc_html( "PIX - Yapay Intermediador" ); ?></span>
+            </div>
+            <div class="section-row">
+                <strong><?php echo __( "Yapay transaction ID:  ", "wc-yapay_intermediador-pix" ); ?></strong>
+                <span><?php echo esc_html( $yapay_transaction_id ); ?></span>
+            </div>
+            <div class="section-row">
+                <strong><?php echo __( "QR Code:   ", "wc-yapay_intermediador-pix" ); ?></strong><br>
+                <div id="yapay-pix-qr">
+                    <object data="<?php echo esc_html( "{$yapay_qrcode_url}" )?>"></object>
+                </div>
+            </div>
+            <div class="section-row">
+                <strong><?php echo __( "Linha digitável:  ", "wc-yapay_intermediador-pix" ); ?></strong>
+                <div>
+                    <span><?php echo esc_html( $yapay_qrcode_code ); ?></span>
+                </div>
+            </div>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
# GitHub Issue #26 
## O que mudou
Visualização de boleto e pix na página de acompanhamento do pedido(cliente).

## Motivação
Não era possível acessar o link do boleto ou qrcode após sair da página de agradecimento.

## Solução proposta
Criei seções dentro da página de visualização de pedido. Essas seções apresentam o link e a linha digitável do boletos, ou o QR Code e pix copia e cola.
![Screenshot from 2022-12-07 07-03-41](https://user-images.githubusercontent.com/71287681/206153829-6a574d3e-76a9-41af-a677-25489fee59cb.png)

![Screenshot from 2022-12-07 07-03-24](https://user-images.githubusercontent.com/71287681/206153861-0e707ec5-148f-4f6c-a13a-a1ed3b0391ea.png)

## Como testar
1. Realizar uma compra usando os métodos boleto ou PIX.
2. Acessar o menu de minha conta.
3. Acessar o menu de pedidos.
4. Acessar o pedido que realizou.