### PR TITLE
Feat/order_transaction_cancellation

### DIFF
--- a/woo-yapay/includes/class-wc-yapay_intermediador-cancellation.php
+++ b/woo-yapay/includes/class-wc-yapay_intermediador-cancellation.php
@@ -1,0 +1,106 @@
+<?php
+
+if ( class_exists( 'WC_Yapay_Intermediador_Cancellation' ) ) return;
+
+/**
+ * WooCommerce Yapay_Intermediador Cancellation class
+ */
+
+class WC_Yapay_Intermediador_Cancellation
+{
+    
+    public function __construct() 
+    {
+        add_action( 'woocommerce_order_status_changed', [ $this, 'on_yapay_status_changed' ], 10, 3 ); 
+    }
+
+    /**
+     * Watch yapay orders status 
+     * @param int $id
+     * @param string $from
+     * @param string $to
+     * @return void
+     */
+    public function on_yapay_status_changed( $id, $from, $to )
+    {
+        $order = wc_get_order( $id );
+
+        $payment_method  = $order->get_payment_method();
+        $payment_methods = [ 'wc_yapay_intermediador_bs', 'wc_yapay_intermediador_pix', 'wc_yapay_intermediador_cc', 'wc_yapay_intermediador_tef' ];
+
+        if ( array_intersect( $payment_methods, [ $payment_method ] ) ) {
+            if ( $to === 'cancelled' ) {
+                $this->cancel_transaction( $payment_method, $id );
+            }
+        }
+
+    }
+
+    /**
+     * Cancel yapay transactions
+     * @param string $payment_method
+     * @param int $order_id
+     * @return void
+     */
+    private function cancel_transaction( $payment_method, $order_id )
+    {
+        include_once( 'class-wc-yapay_intermediador-request.php' );
+
+        $transaction  = $this->get_transaction( $order_id );
+        $option = $this->get_payment_option( $payment_method );
+
+        if ( ! $transaction || ! isset( $transaction->transaction_id ) ) return;
+        if ( ! $option['token_account'] ) return;
+
+        $params = [
+            "access_token"   => $option['token_account'],
+            "transaction_id" => $transaction->transaction_id
+        ];
+
+        $request  = new WC_Yapay_Intermediador_Request();
+        $response = $request->requestData("api/v3/transactions/cancel", $params, $option['environment'], false, "PATCH");
+
+    }
+
+    /**
+     * Get payment method options
+     * @param string $payment_method
+     * @return array|bool
+     */
+    private function get_payment_option( $payment_method )
+    {
+        $option = get_option( "woocommerce_{$payment_method}_settings" );
+
+        if ( $option && ! empty( $option ) ) {
+            if ( ! isset( $option['token_account'] ) || ! $option['token_account'] ) {
+                return false;
+            }
+
+            if ( ! isset( $option['environment'] ) ) {
+                return false;
+            }
+        }
+
+        return $option;
+    }
+
+    /**
+     * Get transaction data
+     * @param int $order_id
+     * @return object|bool
+     */
+    private function get_transaction( $order_id )
+    {
+        include_once( 'class-wc-yapay_intermediador-transactions.php' );
+
+        $transactions = new WC_Yapay_Intermediador_Transactions();
+        $transaction  = $transactions->getTransactionByOrderId( $order_id );
+
+        if ( empty( $transaction ) || ! $transaction ) {
+            return;
+        }
+
+        return $transaction;
+    }
+    
+}

--- a/woo-yapay/includes/class-wc-yapay_intermediador-request.php
+++ b/woo-yapay/includes/class-wc-yapay_intermediador-request.php
@@ -13,7 +13,7 @@ class WC_Yapay_Intermediador_Request{
         return ($environment == 'yes') ? "https://api.intermediador.sandbox.yapay.com.br/" : "https://api.intermediador.yapay.com.br/";
     }
     
-    public function requestData($pathPost, $dataRequest, $environment = "yes", $strResponse = false)
+    public function requestData($pathPost, $dataRequest, $environment = "yes", $strResponse = false, $method = "POST")
     {
         $urlPost = self::getUrlEnvironment($environment).$pathPost;
 
@@ -25,6 +25,9 @@ class WC_Yapay_Intermediador_Request{
         curl_setopt ( $ch, CURLOPT_POSTFIELDS, $dataRequest);
         curl_setopt ( $ch, CURLOPT_SSLVERSION, 6 );
         // curl_setopt ( $ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2 );
+        if ( $method != "POST" ) {
+            curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, $method) ;
+        }
 
         
         if (!($response = curl_exec($ch))) {

--- a/woo-yapay/wc-yapay_intermediador.php
+++ b/woo-yapay/wc-yapay_intermediador.php
@@ -437,3 +437,10 @@ function sendRastreioYapay() {
 
 add_action( 'wp_ajax_sendRastreioYapay', 'sendRastreioYapay' );
 add_action( 'wp_ajax_nopriv_sendRastreioYapay', 'sendRastreioYapay' );
+
+function call_yapay_includes() {
+    include_once( 'includes/class-wc-yapay_intermediador-cancellation.php' );
+    new WC_Yapay_Intermediador_Cancellation();
+}
+
+add_action( 'init', 'call_yapay_includes' );


### PR DESCRIPTION
# GitHub Issue #10 

## O que mudou
Foi criado um meio de cancelar transações.

## Motivação
Poder cancelar transações pelo painel administrativo.

## Solução proposta
Quando um pedido é cancelado é disparado uma requisição de cancelamento de transação para a Yapay.

## Como testar
Efetuar uma compra teste e alterar o status do pedido para 'cancelado'