### PR TITLE
Feat/refactor_log

### DIFF
--- a/woo-yapay/class-wc-yapay_intermediador-bankslip-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-bankslip-gateway.php
@@ -314,6 +314,24 @@ class WC_Yapay_Intermediador_Bankslip_Gateway extends WC_Payment_Gateway {
             $transactionParams["url_payment"] = (string)$tcResponse->data_response->transaction->payment->url_payment;
             $transactionParams["typeful_line"] = (string)$tcResponse->data_response->transaction->payment->linha_digitavel;
             
+            $metas = [
+                'transaction_id' => $transactionParams["transaction_id"],
+                'payment_method' => $transactionParams["payment_method"],
+                'url_payment'    => $transactionParams['url_payment'],
+                'typeful_line'   => $transactionParams['typeful_line']
+            ];
+
+            $result = update_post_meta( $order_id, 'yapay_transaction_data', serialize( $metas ) );
+            
+            if ( $result ) {
+                $log = new WC_Logger();
+                $log->add( 
+                    "yapay-intermediador-transactions-save-", 
+                    "\n\nYAPAY NEW TRANSACTION SAVE : \n" . 
+                    print_r( $transactionParams, true ) 
+                );
+            }
+
             $transactionData->addTransaction($transactionParams);
 
             if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.1', '>=' ) ) {

--- a/woo-yapay/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -420,6 +420,22 @@ class WC_Yapay_Intermediador_Creditcard_Gateway extends WC_Payment_Gateway {
             $transactionParams["payment_method"] = (int)$tcResponse->data_response->transaction->payment->payment_method_id;
             $transactionParams["token_transaction"] = (string)$tcResponse->data_response->transaction->token_transaction;
 
+            $metas = [
+                'transaction_id' => $transactionParams["transaction_id"],
+                'payment_method' => $transactionParams["payment_method"],
+                'split_number'   => $transactionParams['split_number']
+            ];
+
+            $result = update_post_meta( $order_id, 'yapay_transaction_data', serialize( $metas ) );
+            
+            if ( $result ) {
+                $log = new WC_Logger();
+                $log->add( 
+                    "yapay-intermediador-transactions-save-", 
+                    "\n\nYAPAY NEW TRANSACTION SAVE : \n" . 
+                    print_r( $transactionParams, true ) 
+                );
+            }
             
             $transactionData->addTransaction($transactionParams);
 

--- a/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-pix-gateway.php
@@ -338,7 +338,23 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
             $transactionParams["qrcode_original_path"] = (string)$tcResponse->data_response->transaction->payment->qrcode_original_path;
             //$transactionParams["typeful_line"] = (string)$tcResponse->data_response->transaction->payment->linha_digitavel;
             
+            $metas = [
+                'transaction_id'       => $transactionParams["transaction_id"],
+                'qrcode_path'          => $transactionParams["qrcode_path"],
+                'qrcode_original_path' => $transactionParams["qrcode_original_path"]
+            ];
 
+            $result = update_post_meta( $order_id, 'yapay_transaction_data', serialize( $metas ) );
+            
+            if ( $result ) {
+                $log = new WC_Logger();
+                $log->add( 
+                    "yapay-intermediador-transactions-save-", 
+                    "\n\nYAPAY NEW TRANSACTION SAVE : \n" . 
+                    print_r( $transactionParams, true ) 
+                );
+            }
+            
             $transactionData->addTransaction($transactionParams);
             
             if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.1', '>=' ) ) {

--- a/woo-yapay/class-wc-yapay_intermediador-tef-gateway.php
+++ b/woo-yapay/class-wc-yapay_intermediador-tef-gateway.php
@@ -335,7 +335,23 @@ class WC_Yapay_Intermediador_Tef_Gateway extends WC_Payment_Gateway {
             $transactionParams["token_transaction"] = (string)$tcResponse->data_response->transaction->token_transaction;
             $transactionParams["url_payment"] = (string)$tcResponse->data_response->transaction->payment->url_payment;
             //$transactionParams["typeful_line"] = (string)$tcResponse->data_response->transaction->payment->linha_digitavel;
+
+            $metas = [
+                'transaction_id' => $transactionParams["transaction_id"],
+                'qrcode_path'    => $transactionParams["url_payment"]
+            ];
+
+            $result = update_post_meta( $order_id, 'yapay_transaction_data', serialize( $metas ) );
             
+            if ( $result ) {
+                $log = new WC_Logger();
+                $log->add( 
+                    "yapay-intermediador-transactions-save-", 
+                    "\n\nYAPAY NEW TRANSACTION SAVE : \n" . 
+                    print_r( $transactionParams, true ) 
+                );
+            }
+
             $transactionData->addTransaction($transactionParams);
             
             if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.1', '>=' ) ) {

--- a/woo-yapay/includes/class-wc-yapay_intermediador-request.php
+++ b/woo-yapay/includes/class-wc-yapay_intermediador-request.php
@@ -17,6 +17,15 @@ class WC_Yapay_Intermediador_Request{
     {
         $urlPost = self::getUrlEnvironment($environment).$pathPost;
 
+        $log = new WC_Logger();
+        
+        $log->add( 
+            "yapay-intermediador-request-response-", 
+            "\n\nYAPAY NEW REQUEST : \n" . 
+            "URL : $urlPost \n" . 
+            print_r( $dataRequest, true ) 
+        );
+
         $ch = curl_init ( $urlPost );
         
         curl_setopt ( $ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1 );
@@ -37,6 +46,13 @@ class WC_Yapay_Intermediador_Request{
             curl_close ( $ch );
             exit();    
         }
+
+        $log->add( 
+            "yapay-intermediador-request-response-", 
+            "\n\nYAPAY NEW RESPONSE : \n" . 
+            "URL : $urlPost \n" . 
+            print_r( $response, true )
+        );
         
         $httpCode = curl_getinfo ( $ch, CURLINFO_HTTP_CODE );
         

--- a/woo-yapay/wc-yapay_intermediador.php
+++ b/woo-yapay/wc-yapay_intermediador.php
@@ -40,21 +40,6 @@ function wc_gateway_yapay_intermediador_init() {
     }
 }
 
-add_action('admin_menu', 'wc_gateway_yapay_intermediador_log_menu');
-
-function wc_gateway_yapay_intermediador_log_menu() {
-    include_once "includes/class-wc-yapay_intermediador-requests.php";    
-    include_once "includes/class-wc-yapay_intermediador-responses.php"; 
-    add_submenu_page(
-        'woocommerce',
-        'Logs Yapay Intermediador',
-        'Logs Yapay Intermediador',
-        'manage_options',
-        'woocommerce_yapay_intermediador_logs',
-        'html_log_page'
-    );
-}
-
 function html_log_page() {
     include_once 'templates/wc_yapay_intermediador_html_log.php';
 }


### PR DESCRIPTION
# GitHub Issue #32 

## O que mudou
Nova maneira de visualizar e salvar logs.

## Motivação
O formato de log atual do plugin não é o padrão recomendado pelo WooCommerce. Ele salva as informações das transações no banco de dados, e isso pode gerar um acúmulo de dados desnecessários. Além disso há algumas vezes que os dados não são salvos corretamente.


## Solução proposta
Adicionei ao plugin a funcionalidade padrão de logs utilizada pelo WooCoommerce.

## Como testar
Realizar uma compra e verificar a criação de logs dentro do WooCommerce.
