### PR TITLE
Fix: substituição dos nomes de "yapay" para "vinde" e redução do limite de caracteres permitidos de 500 para 50.

### DIFF
--- a/class-wc-yapay_intermediador-bankslip-gateway.php
+++ b/class-wc-yapay_intermediador-bankslip-gateway.php
@@ -189,7 +189,7 @@ class WC_Yapay_Intermediador_Bankslip_Gateway extends WC_Payment_Gateway
         }
 
         $params["token_account"] = $this->get_option("token_account");
-        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.1";
+        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.2";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-bolepix-gateway.php
+++ b/class-wc-yapay_intermediador-bolepix-gateway.php
@@ -167,7 +167,7 @@ class WC_Yapay_Intermediador_Bolepix_Gateway extends WC_Payment_Gateway {
         }
         
         $params["token_account"] = $this->get_option("token_account");
-		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.1";
+		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.2";
         $params["customer[name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 50);
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-bolepix-gateway.php
+++ b/class-wc-yapay_intermediador-bolepix-gateway.php
@@ -168,12 +168,12 @@ class WC_Yapay_Intermediador_Bolepix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
 		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.1";
-        $params["customer[name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 500);
+        $params["customer[name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 50);
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 
         if ( !isset($_POST["billing_persontype"]) && !isset($_POST["billing_cpf"]) || $_POST["billing_persontype"] == 2 ) {
-            $params["customer[trade_name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 500);
-            $params["customer[company_name]"] = substr($_POST["billing_company"], 0 , 500);
+            $params["customer[trade_name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 50);
+            $params["customer[company_name]"] = substr($_POST["billing_company"], 0 , 50);
             $params["customer[cnpj]"] = $_POST["billing_cnpj"];
 
             if (isset( $_POST["yapay_cpfBP"]) && $_POST["yapay_cpfBP"] !== "" ) {

--- a/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -273,7 +273,7 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
             
             $params["token_account"] = $this->get_option("token_account");
             $params["finger_print"] = $_POST["finger_print"];
-            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.1";
+            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.2";
             $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
 			$params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-pix-gateway.php
+++ b/class-wc-yapay_intermediador-pix-gateway.php
@@ -184,7 +184,7 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
         }
         
         $params["token_account"] = $this->get_option("token_account");
-		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.1";
+		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.2";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-tef-gateway.php
+++ b/class-wc-yapay_intermediador-tef-gateway.php
@@ -203,7 +203,7 @@ class WC_Yapay_Intermediador_Tef_Gateway extends WC_Payment_Gateway {
         }
 
         $params["token_account"] = $this->get_option("token_account");
-		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.1";
+		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.2";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Integração Vindi, aguiart0, apiki
 Tags: woocommerce, vindi, intermediador, Vindi Pagamento, payment
 Requires at least: 3.5
 Tested up to: 6.4
-Stable tag: 0.7.1
+Stable tag: 0.7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,6 +51,10 @@ Para dúvidas envie um e-mail para nosso time de Integração: integracao@yapay.
 2. Página de configuração do plugin
 
 == Changelog ==
+
+= 0.7.2 = 20/03/2024
+* Fix: Nomenclatura de yapay para vindi
+* Fix: Diminuição de caracteres permitidos de 500 para 50
 
 = 0.7.1 = 15/03/2024
 * Feat: Adicionando o método de pagamento 'BolePix'

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Plugin Name: WooCommerce Yapay
- * Plugin URI: http://www.yapay.com.br
- * Description: Intermediador de pagamento Yapay para a plataforma WooCommerce.
- * Author: Integração Yapay Intermediador
- * Author URI: http://dev.yapay.com.br/
+ * Plugin Name: Vindi Pagamento WooCommerce
+ * Plugin URI: https://vindi.com.br/formas-de-pagamentos/
+ * Description: Intermediador de pagamento Vindi para a plataforma WooCommerce.
+ * Author: Integração Vindi Intermediador
+ * Author URI: https://vindi.com.br/
  * Version: 0.7.1
- * Text Domain: woo-yapay
+ * Text Domain: vindi-pagamento
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -5,7 +5,7 @@
  * Description: Intermediador de pagamento Vindi para a plataforma WooCommerce.
  * Author: Integração Vindi Intermediador
  * Author URI: https://vindi.com.br/
- * Version: 0.7.1
+ * Version: 0.7.2
  * Text Domain: vindi-pagamento
  */
 


### PR DESCRIPTION
Corrigido o texto dentro do arquivo wc-yapay_intermediador para substituir "yapay" por "vinde", e o arquivo class-wc-yapay_intermediador-bolepix-gateway teve seu limite de caracteres reduzido de 500 para 50.