### PR TITLE
Requisição ajustada para evitar a multiplicação de opções de parcelas exibidas

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -132,10 +132,8 @@ ul li img.tcPaymentFlag:hover{
 }
 
 .qrCodeYapay {
-    margin-left: -75px;
     margin-top: 10px;
-    max-height: 150px;
-    max-width: 300px;
+    max-height: 200px;
 }
 
 /** Order view page */

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -134,6 +134,8 @@ ul li img.tcPaymentFlag:hover{
 .qrCodeYapay {
     margin-left: -75px;
     margin-top: 10px;
+    max-height: 150px;
+    max-width: 300px;
 }
 
 /** Order view page */

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -31,7 +31,6 @@ ul li img.tcPaymentFlag:hover{
     opacity:1 !important;
     -moz-opacity: 1 !important;
     filter: alpha(opacity=100) !important;
-    cursor: pointer;
 }
 
 .linha1 {

--- a/assets/js/credit.js
+++ b/assets/js/credit.js
@@ -201,6 +201,7 @@ class Credit {
         })
             .then((response) => response.json())
             .then((data) => {
+                jQuery("#wc-yapay_intermediador-cc-card-installments").empty()
                 this.renderSplits(data);
                 jQuery("form.checkout").removeClass("processing").unblock();
             })

--- a/class-wc-yapay_intermediador-bankslip-gateway.php
+++ b/class-wc-yapay_intermediador-bankslip-gateway.php
@@ -191,7 +191,7 @@ class WC_Yapay_Intermediador_Bankslip_Gateway extends WC_Payment_Gateway
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.6";
+        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-bolepix-gateway.php
+++ b/class-wc-yapay_intermediador-bolepix-gateway.php
@@ -169,7 +169,7 @@ class WC_Yapay_Intermediador_Bolepix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.6";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
         $params["customer[name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 50);
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -264,7 +264,7 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
             
             $params["token_account"] = $this->get_option("token_account");
             $params["finger_print"] = $_POST["finger_print"];
-            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.6";
+            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
             $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
 			$params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-pix-gateway.php
+++ b/class-wc-yapay_intermediador-pix-gateway.php
@@ -186,7 +186,7 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.6";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-tef-gateway.php
+++ b/class-wc-yapay_intermediador-tef-gateway.php
@@ -205,7 +205,7 @@ class WC_Yapay_Intermediador_Tef_Gateway extends WC_Payment_Gateway {
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.6";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/includes/class-wc-yapay_intermediador-request.php
+++ b/includes/class-wc-yapay_intermediador-request.php
@@ -89,11 +89,11 @@ class WC_Yapay_Intermediador_Request{
             $response = json_decode($response, 1);
         } else if (!$strResponse AND $pathPost == 'v2/transactions/get_by_token') {
             $response = simplexml_load_string($response);
-        } else if (!$strResponse AND $pathPost == 'v2/transactions/pay_complete') { 
+        } else if (!$strResponse AND $pathPost == 'v2/transactions/pay_complete') {
             $response = simplexml_load_string($response);
-        } else if (!$strResponse AND $pathPost == 'v3/sales/trace') { 
+        } else if (!$strResponse AND $pathPost == 'v3/sales/trace') {
             $response = simplexml_load_string($response);
-        } else if (!$strResponse AND $pathPost == 'v1/seller_splits/simulate_split') { 
+        } else if (!$strResponse AND $pathPost == 'v1/seller_splits/simulate_split') {
             $response = simplexml_load_string($response);
         }
         

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Integração Vindi, aguiart0, apiki
 Tags: woocommerce, vindi, intermediador, Vindi Pagamento, payment
 Requires at least: 3.5
 Tested up to: 6.4
-Stable tag: 0.7.6
+Stable tag: 0.7.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,12 +51,11 @@ Para dúvidas envie um e-mail para nosso time de Integração: integracao@yapay.
 2. Página de configuração do plugin
 
 == Changelog ==
+= 0.7.7 = 25/10/2024
+* Fix: Correção da requisição das parcelas
+
 = 0.7.6 = 18/07/2024
 * Fix: Correção de no código de envio
-
-= 0.7.5 = 01/07/2024
-* Fix: Botão copia e cola corrigidos
-* Fix: Código de rastreio sendo salvo no banco de dados
 
 = 0.7.5 = 01/07/2024
 * Fix: Botão copia e cola corrigidos

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -5,7 +5,7 @@
  * Description: Intermediador de pagamento Vindi para a plataforma WooCommerce.
  * Author: Integração Vindi Intermediador
  * Author URI: https://vindi.com.br/
- * Version: 0.7.6
+ * Version: 0.7.7
  * Text Domain: vindi-pagamento
  */
 


### PR DESCRIPTION
## O que Mudou
Adicionado uma limpeza das opções de parcelas antes de cada nova requisição.
Ajusta o método append para evitar a multiplicação de parcelas exibidas ao digitar ou alterar o número do cartão.
Remoção do cursor point sobre as bandeiras.

## Motivação:
Essa mudança foi feita para resolver um problema onde opções de parcelas eram duplicadas cada vez que o usuário digitava números adicionais no campo do cartão, resultando em múltiplas requisições e na replicação das opções.

## Como testar:
1. Com um carrinho com item vá até a pagina checkout.
2. Digite o número de cartão até o fim e verifique as opções de parcelas exibidas.
3. Altere o número, digitando ou apagando caracteres, e observe se as opções se atualizam sem duplicação