### PR TITLE
Ajuste no Tamanho QR Code na Página de Agradecimento

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -162,7 +162,8 @@ ul li img.tcPaymentFlag:hover{
 }
 
 #yapay-order-container #yapay-pix-qr > object{
-    margin-left: -75px;
+    margin-top: 10px;
+    max-height: 200px;
 }
 
 #payment .payment_method_wc_yapay_intermediador_cc img,

--- a/class-wc-yapay_intermediador-bankslip-gateway.php
+++ b/class-wc-yapay_intermediador-bankslip-gateway.php
@@ -191,7 +191,7 @@ class WC_Yapay_Intermediador_Bankslip_Gateway extends WC_Payment_Gateway
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
+        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.8";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-bolepix-gateway.php
+++ b/class-wc-yapay_intermediador-bolepix-gateway.php
@@ -169,7 +169,7 @@ class WC_Yapay_Intermediador_Bolepix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.8";
         $params["customer[name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 50);
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -264,7 +264,7 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
             
             $params["token_account"] = $this->get_option("token_account");
             $params["finger_print"] = $_POST["finger_print"];
-            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
+            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.8";
             $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
 			$params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-pix-gateway.php
+++ b/class-wc-yapay_intermediador-pix-gateway.php
@@ -186,7 +186,7 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.8";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-tef-gateway.php
+++ b/class-wc-yapay_intermediador-tef-gateway.php
@@ -205,7 +205,7 @@ class WC_Yapay_Intermediador_Tef_Gateway extends WC_Payment_Gateway {
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.7";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.8";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Integração Vindi, aguiart0, apiki
 Tags: woocommerce, vindi, intermediador, Vindi Pagamento, payment
 Requires at least: 3.5
 Tested up to: 6.4
-Stable tag: 0.7.7
+Stable tag: 0.7.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,6 +51,9 @@ Para dúvidas envie um e-mail para nosso time de Integração: integracao@yapay.
 2. Página de configuração do plugin
 
 == Changelog ==
+= 0.7.8 = 03/12/2024
+* Fix: Ajuste tamanho do QrCode
+
 = 0.7.7 = 25/10/2024
 * Fix: Correção da requisição das parcelas
 

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -461,3 +461,13 @@ function yapay_enqueue_scripts() {
     }
 }
 add_action('init', 'yapay_enqueue_scripts');
+
+function check_plugin_dependencies() {
+    if ( !class_exists( 'Extra_Checkout_Fields_For_Brazil' ) ) {
+        add_action( 'admin_notices', function() {
+            echo '<div class="error"><p><strong>Brazilian Market on WooCommerce</strong> não está ativo. Certifique-se de ativá-lo para usar as funcionalidades específicas.</p></div>';
+        });
+    }
+}
+
+add_action( 'admin_init', 'check_plugin_dependencies' );

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -5,7 +5,7 @@
  * Description: Intermediador de pagamento Vindi para a plataforma WooCommerce.
  * Author: Integração Vindi Intermediador
  * Author URI: https://vindi.com.br/
- * Version: 0.7.7
+ * Version: 0.7.8
  * Text Domain: vindi-pagamento
  */
 


### PR DESCRIPTION
**O que mudou**  
O tamanho do QR Code na página de agradecimento estava desproporcional à tela. O tamanho foi ajustado para que se encaixe de forma ideal.

**Motivação**  
Corrigir o tamanho do QR Code para melhorar a experiência do usuário.

**Solução proposta**  
Foi definido um tamanho máximo para a imagem do QR Code.

**Como testar**  
Simule uma compra, finalize o pagamento e acesse a página de agradecimento (thank you page). Verifique se o tamanho do QR Code agora se ajusta corretamente à tela.